### PR TITLE
Update C++ Builder-Minghang Yang.sublime-build

### DIFF
--- a/C++ Builder-Minghang Yang.sublime-build
+++ b/C++ Builder-Minghang Yang.sublime-build
@@ -15,7 +15,7 @@
         "name": "Run",
         "shell": true,
         "linux": {
-            "cmd": ["gnome-terminal -e 'bash -c \"\\\"./${file_base_name}\\\";echo;read line;exit; exec bash\"'"]
+            "cmd": ["gnome-terminal -- bash -c \"\\\"./${file_base_name}\\\";echo;read line;exit; exec bash\""]
         },
         "osx": {
             "shell_cmd": "echo 'cd \"${file_path}/\"' > '/tmp/${file_base_name}' && echo './\"${file_base_name}\"' >> '/tmp/${file_base_name}' && echo read >> '/tmp/${file_base_name}' && chmod +x '/tmp/${file_base_name}' && open -a Terminal.app '/tmp/${file_base_name}'"
@@ -28,7 +28,7 @@
         "name": "Build and Run",
         "shell": true,
         "linux": {
-            "cmd": ["g++ -std=c++11 \"${file}\" -o \"${file_base_name}\" && gnome-terminal -e 'bash -c \"\\\"./${file_base_name}\\\";echo;read line;exit; exec bash\"'"]
+            "cmd": ["g++ -std=c++11 \"${file}\" -o \"${file_base_name}\" && gnome-terminal -- bash -c \"\\\"./${file_base_name}\\\";echo;read line;exit; exec bash\""]
         },
         "windows": {
             "shell_cmd": "g++ -std=c++11 \"${file}\" -o \"${file_base_name}.exe\" && start cmd /c \"\"${file_base_name}.exe\" & echo. & pause\""


### PR DESCRIPTION
# Option “-e” is deprecated and might be removed in a later version of gnome-terminal.
# Use “-- ” to terminate the options and put the command line to execute after it.

Each time I build and run a CPP file I got these above 2 messages in my panel. I have modified the CPP script and now it works fine. Please review.